### PR TITLE
Allow a default endpoint when the codelist source is not present

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -3,7 +3,7 @@
 module.exports = function (/* environment, appConfig */) {
   return {
     templateVariablePlugin: {
-      endpoint: 'https://dev.roadsigns.lblod.info/sparql',
+      defaultEndpoint: 'https://dev.roadsigns.lblod.info/sparql',
       zonalLocationCodelistUri:
         'http://lblod.data.gift/concept-schemes/62331E6900730AE7B99DF7EF',
       nonZonalLocationCodelistUri:


### PR DESCRIPTION
In some cases like when working with old data the source of the codelist is not present on the html, this aims to solve it allowing the plugin host to specify a default endpoint to use in those cases