### PR TITLE
fix(selection-handler): handle cases where selection is empty

### DIFF
--- a/addon/components/editor-plugins/template-variable-card.js
+++ b/addon/components/editor-plugins/template-variable-card.js
@@ -107,9 +107,13 @@ export default class EditorPluginsTemplateVariableCardComponent extends Componen
   selectionChanged() {
     this.showCard = false;
     this.selectedVariable = undefined;
+    const selectedRange = this.args.controller.selection.lastRange;
+    if (!selectedRange) {
+      return;
+    }
     const fullDatastore = this.args.controller.datastore;
     const limitedDatastore = this.args.controller.datastore.limitToRange(
-      this.args.controller.selection.lastRange,
+      selectedRange,
       'rangeIsInside'
     );
     const mapping = limitedDatastore
@@ -211,6 +215,7 @@ export default class EditorPluginsTemplateVariableCardComponent extends Componen
       this.multiSelect = false;
     }
   }
+
   wrapInLocation(value) {
     return `
       <span property="https://data.vlaanderen.be/ns/mobiliteit#plaatsbepaling">


### PR DESCRIPTION
selection.lastRange can be null
mainly happens when clicking on toolbar and switching to attachments in GN