### PR TITLE
Insert codelist name instead of the word 'codelist'

### DIFF
--- a/addon/components/insert-variable-card.js
+++ b/addon/components/insert-variable-card.js
@@ -26,10 +26,9 @@ export default class EditorPluginsInsertCodelistCardComponent extends Component 
   insert() {
     const uri = `http://data.lblod.info/mappings/${uuidv4()}`;
     let contentSpan;
-    if (
-      this.selectedVariableType === 'location' ||
-      this.selectedVariableType === 'codelist'
-    ) {
+    if (this.selectedVariableType === 'codelist') {
+      contentSpan = `<span property="ext:content">\${${this.selectedCodelist.label}}</span>`;
+    } else if (this.selectedVariableType === 'location') {
       contentSpan = `<span property="ext:content">\${${this.selectedVariableType}}</span>`;
     } else if (this.selectedVariableType === 'date') {
       contentSpan = `<span property="ext:content" ${


### PR DESCRIPTION
This PR ensures that the codelist label is displayed instead of the word 'codelist' when inserting a variable of type codelist. Solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3741